### PR TITLE
fix small syntax errors

### DIFF
--- a/bin/user/as3935.py
+++ b/bin/user/as3935.py
@@ -150,7 +150,7 @@ class AS3935(StdService):
                                     (dbcol, memcol))
 
         # configure the sensor
-        self.sensor = RPi_AS3935(address=addr, bus=bus)
+        self.sensor = RPi_AS3935.RPi_AS3935(address=addr, bus=bus)
         self.sensor.set_indoors(indoors)
         self.sensor.set_noise_floor(noise_floor)
         self.sensor.calibrate(tun_cap=calib)
@@ -230,5 +230,5 @@ class AS3935(StdService):
                 loginf("strike at %s km" % distance)
                 self.data.append((strike_ts, distance))
                 self.save_data(strike_ts, distance)
-        except Exception, e:
+        except Exception as e:
             logerr("callback failed: %s" % e)

--- a/bin/user/as3935.py
+++ b/bin/user/as3935.py
@@ -5,8 +5,8 @@
 A service for weewx that reads the AS3935 lightning sensor range.  This service
 will add two fields to each archive record:
 
-  lightning_strikes - number of lightning strikes in the past interval
-  avg_distance - average distance of the lightning strikes
+  lightning_strike_count - number of lightning strikes in the past interval
+  lightning_distance - average distance of the lightning strikes
 
 To track these and use them in reports and plots, extend the weewx database
 schema as described in the weewx customization guide.
@@ -87,7 +87,7 @@ if weewx.__version__ < "3.2":
                                    weewx.__version__)
 
 # uncomment this if you want to sum counts instead of getting counts per period
-#weewx.accum.extract_dict['lightning_strikes'] = weewx.accum.Accum.sum_extract
+#weewx.accum.extract_dict['lightning_strike_count'] = weewx.accum.Accum.sum_extract
 
 schema = [('dateTime', 'INTEGER NOT NULL PRIMARY KEY'),
           ('usUnits', 'INTEGER NOT NULL'),
@@ -99,17 +99,36 @@ def get_default_binding_dict():
             'table_name': 'archive',
             'schema': 'user.as3935.schema'}
 
-def logmsg(level, msg):
-    syslog.syslog(level, 'as3935: %s' % msg)
+try:
+    # Test for new-style weewx logging by trying to import weeutil.logger
+    import weeutil.logger
+    import logging
+    log = logging.getLogger("user.as3935")
 
-def logdbg(msg):
-    logmsg(syslog.LOG_DEBUG, msg)
+    def logdbg(msg):
+        log.debug(msg)
 
-def loginf(msg):
-    logmsg(syslog.LOG_INFO, msg)
+    def loginf(msg):
+        log.info(msg)
 
-def logerr(msg):
-    logmsg(syslog.LOG_ERR, msg)
+    def logerr(msg):
+        log.error(msg)
+
+except ImportError:
+    # Old-style weewx logging
+    import syslog
+
+    def logmsg(level, msg):
+        syslog.syslog(level, 'user.E3DC: %s' % msg)
+
+    def logdbg(msg):
+        logmsg(syslog.LOG_DEBUG, msg)
+
+    def loginf(msg):
+        logmsg(syslog.LOG_INFO, msg)
+
+    def logerr(msg):
+        logmsg(syslog.LOG_ERR, msg)
 
 class AS3935(StdService):
     def __init__(self, engine, config_dict):
@@ -197,8 +216,8 @@ class AS3935(StdService):
         if 'usUnits' in pkt and pkt['usUnits'] == weewx.US:
             avg = weewx.units.convert((avg, 'km', 'group_distance'), 'mile')[0]
         # save the count and average
-        pkt['avg_distance'] = avg
-        pkt['lightning_strikes'] = count
+        pkt['lightning_distance'] = avg
+        pkt['lightning_strike_count'] = count
         # clear the count and average
         self.data = []
 
@@ -219,7 +238,7 @@ class AS3935(StdService):
             time.sleep(0.003)
             reason = self.sensor.get_interrupt()
             if reason == 0x01:
-                loginf("noise level too high - adjusting")  
+                loginf("noise level too high - adjusting (old value %s)" % self.sensor.get_noise_floor())
                 self.sensor.raise_noise_floor()
             elif reason == 0x04:
                 loginf("detected disturber - masking")

--- a/install.py
+++ b/install.py
@@ -15,7 +15,7 @@ class AS3935Installer(ExtensionInstaller):
             description='Capture lightning data from AS3935 hardware',
             author="Matthew Wall",
             author_email="mwall@users.sourceforge.net",
-            process_services='user.as3935.AS3935',
+            data_services='user.as3935.AS3935',
             config={
                 'AS3935': {
                     'address': '3',


### PR DESCRIPTION
The extension crashed due to 2 small syntax errors. 

In line 233 there is a comma instead of `as` within the `except` clause, causing the following error:

```
Nov 11 14:09:41 lightning weewx[2634] CRITICAL __main__:     ****      self.loadServices(config_dict)
Nov 11 14:09:41 lightning weewx[2634] CRITICAL __main__:     ****    File "/usr/share/weewx/weewx/engine.py", line 161, in loadServices
Nov 11 14:09:41 lightning weewx[2634] CRITICAL __main__:     ****      obj = weeutil.weeutil.get_object(svc)(self, config_dict)
Nov 11 14:09:41 lightning weewx[2634] CRITICAL __main__:     ****    File "/usr/share/weewx/weeutil/weeutil.py", line 1335, in get_object
Nov 11 14:09:41 lightning weewx[2634] CRITICAL __main__:     ****      mod = __import__(module)
Nov 11 14:09:41 lightning weewx[2634] CRITICAL __main__:     ****    File "/usr/share/weewx/user/as3935.py", line 233
Nov 11 14:09:41 lightning weewx[2634] CRITICAL __main__:     ****      except Exception, e:
Nov 11 14:09:41 lightning weewx[2634] CRITICAL __main__:     ****                      ^
Nov 11 14:09:41 lightning weewx[2634] CRITICAL __main__:     ****  SyntaxError: invalid syntax
Nov 11 14:09:41 lightning weewx[2634] CRITICAL __main__:     ****  Exiting.
```

Then the instantiation of class `RPi_AS3935` from module `RPi_AS3935` was not correct:

```
Nov 11 14:20:30 lightning weewx[1887] CRITICAL __main__:     ****    File "/usr/share/weewx/weewxd", line 148, in main
Nov 11 14:20:30 lightning weewx[1887] CRITICAL __main__:     ****      engine = weewx.engine.StdEngine(config_dict)
Nov 11 14:20:30 lightning weewx[1887] CRITICAL __main__:     ****    File "/usr/share/weewx/weewx/engine.py", line 93, in __init__
Nov 11 14:20:30 lightning weewx[1887] CRITICAL __main__:     ****      self.loadServices(config_dict)
Nov 11 14:20:30 lightning weewx[1887] CRITICAL __main__:     ****    File "/usr/share/weewx/weewx/engine.py", line 161, in loadServices
Nov 11 14:20:30 lightning weewx[1887] CRITICAL __main__:     ****      obj = weeutil.weeutil.get_object(svc)(self, config_dict)
Nov 11 14:20:30 lightning weewx[1887] CRITICAL __main__:     ****    File "/usr/share/weewx/user/as3935.py", line 153, in __init__
Nov 11 14:20:30 lightning weewx[1887] CRITICAL __main__:     ****      self.sensor = RPi_AS3935(address=addr, bus=bus)
Nov 11 14:20:30 lightning weewx[1887] CRITICAL __main__:     ****  TypeError: 'module' object is not callable
Nov 11 14:20:30 lightning weewx[1887] CRITICAL __main__:     ****  Exiting.
```

See also https://github.com/pcfens/RaspberryPi-AS3935/issues/30